### PR TITLE
Sign open letter

### DIFF
--- a/index.md
+++ b/index.md
@@ -43,3 +43,4 @@ Signed,
 - Parker Higgins
 - Noel Georgi
 - Hayden Seay
+- Colin Watson (Former Debian Technical Committee member)


### PR DESCRIPTION
I'm very sorry to have reached the point where I feel compelled to sign
this letter, after being inspired by free software ideals and spending
20 years working on free software.  I'm still committed to the ideals of
free software, but those do not reside solely in the FSF.  RMS should
not be allowed to blithely return with no indication of sincerely making
amends to the people he's hurt, and the fact that he's doing so
indicates that the FSF is either complicit or supine; it no longer
really matters which.