### PR TITLE
Added Alan

### DIFF
--- a/index.md
+++ b/index.md
@@ -80,3 +80,4 @@ Signed,
 - Peter Hunt
 - Enum Cohrs
 - Federico Mena Quintero (GNOME)
+- Alan Ball


### PR DESCRIPTION
I was disheartened to see the board take such a destructive move against the community. RMS is not free software, and the FSF should not be a platform or outlet for RMS's bizarre and harmful behavior. We need a board who looks out for liberty and not those who hold positions of power. Free software that does not project solidarity for marginalized groups will be later attacked with the same language that RMS has used against those marginalized. Its a moral imperative to use what power we have for good, but importantly free software will not survive if it fails to do so.