### PR TITLE
Sign open letter

### DIFF
--- a/index.md
+++ b/index.md
@@ -174,3 +174,4 @@ Signed,
 - Sean O'Brien
 - Amy Russell
 - Nicolas Schier (Debian maintainer)
+- Ian Jackson (Former Debian Project Leader; former President, Software in the Public Interest; GNU Maintainer)


### PR DESCRIPTION
I published my first Free Software in 1989, under the GNU General
Public Licence.  I remain committed to the ideal of software freedom,
for everyone.

When the CSAIL list incident blew up I was horrified to read the
stories of RMS's victims.  We have collectively failed those people
and I am glad to see than many of us are working to make a better
community.

I have watched with horror as RMS has presided over, and condoned,
astonishingly horrible behaviour in many GNU Project discussion
venues.

The Free Software Foundation Board are doing real harm by reinstating
an abuser.  I had hoped for and expected better from them.

RMS's vision and ideals of software freedom have been inspiring to me.
But his past behaviour and current attitudes mean he must not and can
not be in a leadership position in the Free Software community.