### PR TITLE
Update to Index.md on behalf of Mozilla.

### DIFF
--- a/index.md
+++ b/index.md
@@ -272,6 +272,7 @@ Signed,
 - Michael Schechter
 - Mike Linksvayer
 - Mikel Johnson
+- Mitchell Baker, on behalf of Mozilla.
 - Morgan-Christopher Brooks
 - Morgan `indrora` Gangwere
 - Morgan Thomas


### PR DESCRIPTION
We are long past the point where we can pretend that the most important thing about software freedom is the software. We cannot demand better from the internet if we do not demand better from our leaders, our colleagues and ourselves. Along with the Open Source Diversity Community, Outreachy and the Software Freedom Conservancy project, we support this petition.