### PR TITLE
Add Michael MacTaggert

### DIFF
--- a/index.md
+++ b/index.md
@@ -497,6 +497,7 @@ Signed,
 - Michael Gat
 - Michael Hoffmann
 - Michael Juarez
+- Michael `lethargilistic` MacTaggert (Programming Discussions server on Discord)
 - Michael `NCommander` Casadevall (Ubuntu Core Developer, former Debian Developer, former FSF Savannah Administrator)
 - Michael `ovyerus` Mitchell
 - Michael Perron


### PR DESCRIPTION
RMS's time in the sun is over. He could have retired quietly. But he's just yet another old white man who refuses to prepare his precious sand castle for his inevitable death and can't even imagine giving up symbolic power while he's still alive. We don't need him or anybody else who intends to be like him. Cast them out.