### PR TITLE
Add my name

### DIFF
--- a/index.md
+++ b/index.md
@@ -770,6 +770,7 @@ Signed,
 - Taowa (Debian Developer, former LP keynote panelist)
 - Thaddée Tyl
 - TheEvilSkeleton
+- Thierry Carrez (Open Infrastructure Foundation, Python Software Foundation fellow)
 - Thomas Wouters (former GNU contributor)
 - Thom Chiovoloni
 - Tianon Gravi


### PR DESCRIPTION
A majority of the FSF board placed an unhealthy personality cult above the ideals of free software, they need to be removed.