### PR TITLE
Sign rms-open-letter

### DIFF
--- a/index.md
+++ b/index.md
@@ -583,6 +583,7 @@ Signed,
 - Richard Guy Briggs (FreeS/WAN kernel, OCLUG founding board, kaudit)
 - Richard Maw
 - Richard Mehlinger
+- Richard "RichiH" Hartmann (Debian Developer; ex: freenode & OFTC; FOSDEM, CCC, DebConf); see commit message
 - Richard Schneeman
 - Rich Felker (musl libc)
 - Richo Healey


### PR DESCRIPTION
I could not find the voting results and I do not believe that the
named voting record is pulic (yet).

It's the very definition of chilling effects that people may
disagree but not feel safe to speak out. This is mirrored in my
own social circles where there was outrage behind the scenes, but
almost no truly public comments. If there were public comments,
they were not directly quoting the fsf/rms news, merely alluding
to it. Only very few people, myself included, spoke out publicly
and citing what they spoke out about. Within roughly 24 hours,
this has changed dramatically and more and more people are
speaking out. I do not know, but I would be willing to bet, that
a substantial fraction of the people speaking out now have been
encouraged by, or needed, the feeling of common outrage. Undoing
chilling effects takes years and more.

I do not have enough information to judge everyone on the FSF
board and from what I heard through the grapevine there was
opposition to re-instating rms. I sincerely hope that the FSF
board and membership speaks up in public opposition.

If any board members were to voice public copposition and were
to work from the inside to right this wrong, I would not expect
them to stand down. It might still be preferable for the entire
board to stand down and people being partially re-instated if
they were, in fact, impacted by chilling effects and working to
right this wrong. I would expect any public speaking out to happen
in a matter of days, not more. A week from now, the concerns above
are void.

Signed-off-by: Richard Hartmann <richih@richih.org>