### PR TITLE
Remove claim regarding "defense of pedophilia"

### DIFF
--- a/appendix.md
+++ b/appendix.md
@@ -12,24 +12,23 @@ He regularly and repeatedly makes comments about “the dishonest law that label
 [5]: https://stallman.org/archives/2017-sep-dec.html#13_November_2017_(Jelani_Maraj)
 [6]: https://stallman.org/archives/2018-may-aug.html#14_May_2018_(Death_sentence_in_Sudan)
 
-Of a woman having sex with a minor, he said “I wish an attractive woman had 'abused' me that way when I was 14.”[7] He directly addressed child pornography by saying that “making such photos should be a crime, and is a crime, but that is no reason to prohibit possessing copies of the photos.”[8] He defended pedophilia, in general, in saying that “there is little evidence to justify the widespread assumption that willing participation in pedophilia hurts children.”[9]
+Of a woman having sex with a minor, he said “I wish an attractive woman had 'abused' me that way when I was 14.”[7] He directly addressed child pornography by saying that “making such photos should be a crime, and is a crime, but that is no reason to prohibit possessing copies of the photos.”[8]
 
 [7]: https://stallman.org/archives/2015-mar-jun.html#5_June_2015_(Law_being_an_ass)
 [8]: https://stallman.org/archives/2014-jul-oct.html#26_October_2014_(Prison_for_cartoon)
-[9]: https://stallman.org/archives/2012-nov-feb.html#04_January_2013_(Pedophilia)
                                      
-In 2015 and 2016 RMS made three posts on his website about Down’s syndrome. He recommended that, should someone find out they are pregnant and the child tests positive for Down’s syndrome “the right course of action for the woman is to terminate the pregnancy.”[10] He referred to people deciding to “carry fetuses with Down’s syndrome to term” as “perverse” and said that there is “nothing virtuous” in “[increasing] the number of people that have Down’s syndrome.”[11] He also said that “when a fetus has Down's syndrome, you should abort it and try again.”[12] On at least one occasion RMS likened having a child with Down’s syndrome to having a pet.[13]
+In 2015 and 2016 RMS made three posts on his website about Down’s syndrome. He recommended that, should someone find out they are pregnant and the child tests positive for Down’s syndrome “the right course of action for the woman is to terminate the pregnancy.”[9] He referred to people deciding to “carry fetuses with Down’s syndrome to term” as “perverse” and said that there is “nothing virtuous” in “[increasing] the number of people that have Down’s syndrome.”[10] He also said that “when a fetus has Down's syndrome, you should abort it and try again.”[11] On at least one occasion RMS likened having a child with Down’s syndrome to having a pet.[12]
 
-[10]: https://web.archive.org/web/20210319210116/https://stallman.org/archives/2016-jul-oct.html#31_October_2016_(Down's_syndrome)
-[11]: https://stallman.org/archives/2015-jul-oct.html#21_October_2015_(Mistaking_a_fetus_for_a_baby)
-[12]: https://stallman.org/archives/2016-mar-jun.html#23_April_2016_(Fetuses_with_Downs_syndrome)
-[13]: https://web.archive.org/web/20161107050933/https://www.stallman.org/archives/2016-jul-oct.html#31_October_2016_(Down's_syndrome)
+[9]: https://web.archive.org/web/20210319210116/https://stallman.org/archives/2016-jul-oct.html#31_October_2016_(Down's_syndrome)
+[10]: https://stallman.org/archives/2015-jul-oct.html#21_October_2015_(Mistaking_a_fetus_for_a_baby)
+[11]: https://stallman.org/archives/2016-mar-jun.html#23_April_2016_(Fetuses_with_Downs_syndrome)
+[12]: https://web.archive.org/web/20161107050933/https://www.stallman.org/archives/2016-jul-oct.html#31_October_2016_(Down's_syndrome)
 
-RMS has spent years on a campaign against using people’s correct pronouns. This is poorly disguised transphobia. In the original publication of the GNU Kind Communication Guidelines, he said “there are various ways to express gender neutrality in third-person singular pronouns in English; you do not have to use 'they.'”[14] This text has since been updated, but is still transphobic.[15] The main page on his web site includes the statement that  “‘They’ is plural — for singular antecedents, use singular gender-neutral pronouns.”[16]
+RMS has spent years on a campaign against using people’s correct pronouns. This is poorly disguised transphobia. In the original publication of the GNU Kind Communication Guidelines, he said “there are various ways to express gender neutrality in third-person singular pronouns in English; you do not have to use 'they.'”[13] This text has since been updated, but is still transphobic.[14] The main page on his web site includes the statement that  “‘They’ is plural — for singular antecedents, use singular gender-neutral pronouns.”[15]
 
-[14]: https://web.archive.org/web/20181022140126/https://www.gnu.org/philosophy/kind-communication.html
-[15]: https://www.gnu.org/philosophy/kind-communication.html
-[16]: https://stallman.org
+[13]: https://web.archive.org/web/20181022140126/https://www.gnu.org/philosophy/kind-communication.html
+[14]: https://www.gnu.org/philosophy/kind-communication.html
+[15]: https://stallman.org
 
 [Return to the main page][17]
 


### PR DESCRIPTION
I'm writing this PR purely in the interest of making this letter's appendix more objective. I don't support or admonish this letter, and I don't want to step on anyone's toes or get involved in a big political mess. If you don't like my PR, you can close it off, but my hope is that it'll be accepted or at least discussed properly.

This PR deletes the following text (and updates the citation numbers to be accurate):

```markdown
He defended pedophilia, in general, in saying that “there is little evidence to justify the widespread assumption that willing participation in pedophilia hurts children.”[9]
```

If we look at the cited reference, we find the following entry on Stallman's blog:

> 04 January 2013 (Pedophilia)
> There is little evidence to justify the [widespread assumption that willing participation in pedophilia hurts children](https://www.theguardian.com/society/2013/jan/03/paedophilia-bringing-dark-desires-light).
> 
> Granted, children may not dare say no to an older relative, or may not realize they could say no; in that case, even if they do not overtly object, the relationship may still feel imposed to them. That's not willing participation, it's imposed participation, a different issue.

I do not agree that Stallman's post constitutes, as the letter's text says, a _"defense of pedophilia"_. He's linking to, and quoting/paraphrasing an article published in The Guardian, which says:

> A liberal professor of psychology who studied in the late 1970s will see things very differently from someone working in child protection, or with convicted sex offenders. There is, astonishingly, not even a full academic consensus on whether consensual paedophilic relations necessarily cause harm.
> [...]
> Even now there is no academic consensus on that fundamental question – as Goode found. Some academics do not dispute the view of Tom O'Carroll, a former chairman of PIE and tireless paedophilia advocate with a conviction for distributing indecent photographs of children following a sting operation, that society's outrage at paedophilic relationships is essentially emotional, irrational, and not justified by science. "It is the quality of the relationship that matters," O'Carroll insists. "If there's no bullying, no coercion, no abuse of power, if the child enters into the relationship voluntarily … the evidence shows there need be no harm."

The article seems to be discussing the surprising lack of scientific consensus concerning some aspects of pedophilia. Anyone could read this article and link to it saying, "it appears that there is little evidence to justify the assumption that willing participation in pedophilia hurts children". This is the point that the The Guardian piece is making, that there is a lack of scientific consensus on this matter.

I don't think that by merely repeating The Guardian's statement, or by writing the statement that followed it in his post, that Stallman actually engaged in what this open letter describes as a _"defense of pedophilia"_, and think it would be more accurate if this claim was removed.

Again, please don't mob me for proposing this change. I'm not trying to upset anyone or to make any kind of defense or admonishment of Stallman. I just think this letter could stand to remove a misleading claim.