### PR TITLE
translated appendix to french and change index link to github one

### DIFF
--- a/appendix.fr.md
+++ b/appendix.fr.md
@@ -1,0 +1,36 @@
+RMS a un historique de mauvais traitements envers les femmes et de les rendre mal à l'aise, peu sûres et indésirables. Pour les incidents relatifs à RMS et au MIT, veuillez consulter : <https://selamjie.medium.com/remove-richard-stallman-appendix-a-a7e41e784f88>.
+
+Les opinions de RMS sur le viol et les lois sur le sexe impliquant des enfants ont été discutées publiquement à l'automne 2019, lorsque Selam G a écrit à leur sujet.[1] Particulièrement glaçant est le moment où Stallman aborde les accusations selon lesquelles Marvin Minsky a agressé sexuellement l'une des victimes du trafic de Jeffrey Epstein (Virginia Giuffre) en disant “mais le scénario le plus plausible est qu'elle s'est présentée à lui comme entièrement consentante".[2] RMS dénonce le fait qu'il ne s'agit pas d'une "agression sexuelle" parce que l'expression "agression présuppose qu'il a utilisé la force ou la violence" alors que le rapport en question "ne dit rien de tel".[3] Plutôt que d'en discuter davantage, concentrons-nous sur son site web personnel, où il partage également son point de vue sur le fait que les mineurs sont "tout à fait consentants"[4] (Note : Alors que plusieurs reportages ont déformé la position de Stallman en discutant des allégations contre Minsky, Stallman a précédemment exprimé des opinions qui étaient en accord avec la dite représentation inexacte).
+
+[1]: https://selamjie.medium.com/remove-richard-stallman-fec6ec210794
+[2]: https://www.vice.com/en/article/9ke3ke/famed-computer-scientist-richard-stallman-described-epstein-victims-as-entirely-willing
+[3]: https://www.vice.com/en/article/9ke3ke/famed-computer-scientist-richard-stallman-described-epstein-victims-as-entirely-willing
+[4]:  https://web.archive.org/web/20180924231708/https://stallman.org/archives/2018-jul-oct.html#23_September_2018_(Cody_Wilson)
+
+Il fait régulièrement et à plusieurs reprises des commentaires sur "la loi malhonnête qui qualifie de 'viol' les relations sexuelles avec des adolescents, même s'ils sont consentants".[5] Il compare la loi américaine à la loi soudanaise en disant que "les lois américaines qui définissent le 'viol' comme incluant les relations sexuelles volontaires avec des personnes de moins de N ans (où N varie)" et que "les deux lois falsifient la signification du 'viol'".[6] 
+
+[5]: https://stallman.org/archives/2017-sep-dec.html#13_November_2017_(Jelani_Maraj)
+[6]: https://stallman.org/archives/2018-may-aug.html#14_May_2018_(Death_sentence_in_Sudan)
+
+À propos d'une femme ayant des relations sexuelles avec un mineur, il a déclaré : "J'aurais aimé qu'une femme séduisante m'ait "abusé" de cette façon quand j'avais 14 ans.[7] Il a directement abordé la question de la pornographie infantile en déclarant que "faire de telles photos devrait être un crime, et c'est un crime, mais ce n'est pas une raison pour interdire la possession de copies de ces photos".[8] Il a défendu la pédophilie, en général, en disant que "il y a peu de preuves pour justifier l'hypothèse répandue que la participation volontaire à la pédophilie fait du mal aux enfants."[9] *Note : RMS s'est excusé pour ce commentaire le 14 septembre 2019. [Citation](https://stallman.org/archives/2019-jul-oct.html#14_September_2019_(Sex_between_an_adult_and_a_child_is_wrong)). Modification effectuée : 24 mars, 2021 - 08:50 EDT.*
+
+[7]: https://stallman.org/archives/2015-mar-jun.html#5_June_2015_(Law_being_an_ass)
+[8]: https://stallman.org/archives/2014-jul-oct.html#26_October_2014_(Prison_for_cartoon)
+[9]: https://stallman.org/archives/2012-nov-feb.html#04_January_2013_(Pedophilia)
+
+En 2015 et 2016, RMS a publié trois messages sur son site web concernant le syndrome de Down. Il a recommandé que, si une personne découvre qu'elle est enceinte et que l'enfant est testé positif pour la trisomie 21, " la bonne ligne de conduite pour la femme est d'interrompre la grossesse "[10] Il a qualifié de " perverses " les personnes qui décident de " porter à terme des fœtus atteints de trisomie 21 " et a déclaré qu'il n'y avait " rien de vertueux " à " [augmenter] le nombre de personnes atteintes de trisomie 21 "[11]. "Il a également déclaré que "lorsqu'un fœtus est atteint du syndrome de Down, il faut l'avorter et réessayer"[12]. à au moins une occasion, RMS a comparé le fait d'avoir un enfant atteint du syndrome de Down à celui d'avoir un animal de compagnie[13].
+
+[10]: https://web.archive.org/web/20210319210116/https://stallman.org/archives/2016-jul-oct.html#31_October_2016_(Down's_syndrome)
+[11]: https://stallman.org/archives/2015-jul-oct.html#21_October_2015_(Mistaking_a_fetus_for_a_baby)
+[12]: https://stallman.org/archives/2016-mar-jun.html#23_April_2016_(Fetuses_with_Downs_syndrome)
+[13]: https://web.archive.org/web/20161107050933/https://www.stallman.org/archives/2016-jul-oct.html#31_October_2016_(Down's_syndrome)
+
+RMS a passé des années à mener une campagne contre l'utilisation des pronoms corrects des personnes. Il s'agit ici d'une transphobie peu camouflée. Dans la publication originale des directives de communication de GNU Kind, il a déclaré " il existe plusieurs façons d'exprimer la neutralité du genre dans les pronoms singuliers de la troisième personne en anglais ; vous n'êtes pas obligé d'utiliser 'they' "[14] Ce texte a depuis été mis à jour, mais il est toujours transphobe[15] La page principale de son site Web comprend la déclaration suivante : " 'They' est pluriel - pour les antécédents singuliers, utilisez des pronoms neutres du genre au singulier "[16].
+
+[14]: https://web.archive.org/web/20181022140126/https://www.gnu.org/philosophy/kind-communication.html
+[15]: https://www.gnu.org/philosophy/kind-communication.html
+[16]: https://stallman.org
+
+[Retour à la page principale][17]
+
+[17]: https://rms-open-letter.github.io/

--- a/index.fr.md
+++ b/index.fr.md
@@ -12,6 +12,6 @@ Nous demandons instamment à ceux qui sont en mesure de le faire de cesser de so
 
 [Nous avons détaillé plusieurs incidents publics du comportement de RMS][1]. Certains d'entre nous ont leurs propres histoires à propos de RMS et de leurs interactions avec lui, des choses qui ne sont pas capturées dans des fils de discussion ou sur des vidéos. Nous espérons que vous lirez ce qui a été partagé et que vous réfléchirez au mal qu'il a fait à notre communauté et aux autres.
 
-[1]: https://rms-open-letter.github.io/appendix
+[1]: https://github.com/rms-open-letter/rms-open-letter.github.io/blob/main/appendix.fr.md
 
 Pour signer, veuillez envoyer un e-mail à digitalautonomy at riseup.net ou [ouvrez une pull request](https://github.com/rms-open-letter/rms-open-letter.github.io/pulls).


### PR DESCRIPTION
**important**: the original appendix link points to the built HTML page, but I figured that translations are only handled on github side for now so i just made the link point to the github file (which will render it with the usual github markdown renderer)