### PR TITLE
Add Exherbo Linux to the organisations

### DIFF
--- a/index.md
+++ b/index.md
@@ -55,6 +55,7 @@ Signed,
 1. CommitChange
 1. Dot HQ
 1. Echap
+1. Exherbo Linux
 1. Fivnex
 1. Freedom of the Press Foundation
 1. The FreeDOS Project (@freedos_project)


### PR DESCRIPTION
Signing as Exherbo Linux as per our internal discussion.