### PR TITLE
Adding context to Rachel Lawson as a maintainer of Drupal

### DIFF
--- a/index.md
+++ b/index.md
@@ -1774,7 +1774,7 @@ identification purposes only and does not constitute endorsement.)</small>
 1. Rachel Chalmers (boardmember, The Ada Initiative)
 1. Rachel Domagalski
 1. Rachel Kadel
-1. Rachel Lawson
+1. Rachel Lawson (One of Drupal's many maintainers)
 1. Rafael Bautista
 1. Rafael Silva
 1. Rafael Tovar


### PR DESCRIPTION
It seems right to have context behind the names - where they are coming from and why it is important they speak up.