### PR TITLE
Sign the letter as io mintz

### DIFF
--- a/index.md
+++ b/index.md
@@ -1110,6 +1110,7 @@ identification purposes only and does not constitute endorsement.)</small>
 1. Ilya Kreymer
 1. imSofi
 1. intrigeri (Debian Developer, Tails Developer)
+1. io mintz
 1. Ioanna Dimitriou (Igalia)
 1. Ioannis Cherouvim
 1. Irina Rempt


### PR DESCRIPTION
I noticed that sort -u wasn't enough to keep the list sorted. I had to use -f -u for a case-insensitive sort as well.