### PR TITLE
Signature and statement of defcon201, defcon group affiliate.

### DIFF
--- a/index.md
+++ b/index.md
@@ -60,6 +60,7 @@ Signed,
 1. Cusy
 1. DataMade
 1. Data + Feminism Lab, MIT
+1. DC201 (Defcon group, Jersey City, NJ)
 1. Dot HQ
 1. Echap
 1. Exherbo Linux


### PR DESCRIPTION
While acknowledging RMS's role in creating the GPL, and RMS's contributions
to the theory and ethics of Free software as a concept,

While Acknowledging RMS's role in founding the FSF and contributions fo Free
software as a movement,

While Acknowledging RMS's contributions to code, and the creation of a Free
compiler, toolchain, and tools to help boot strap an ecosystem of community
oriented and more ethical model of software development,

We must widely condemn past statements and actions of Richard M Stallman as
pertaining to women, including transwomen, and his behavior that has chased
people out of the Free software movement.

We will make the statement that holding Mr Stallman accountable for his actions
does not cancel his past works, does not cancel Free software, and does not
cancel ethics.

We will make the further statement, that even as we hold Free software ethics
as a standard, this is not the only ethical standard we subscribe to. These
ethics include acknowledgement of rights of women, including trans-women, and
the disabled, as well as making all guests and members feel welcome.

It is under these conditions we must condemn the reinstatement of Richard M
Stallman to the board of the FSF, as well as the secretive, underhanded manner
of which RMS was re-introduced to the board

Signed

[DC201](https://defcon201.org), Defcon Group affiliate, Jersey City, NJ