### PR TITLE
rescinding DC201 signature due to pending internal DCG discussion

### DIFF
--- a/index.md
+++ b/index.md
@@ -60,7 +60,6 @@ Signed,
 1. Cusy
 1. DataMade
 1. Data + Feminism Lab, MIT
-1. DC201 (Defcon group, Jersey City, NJ)
 1. Dot HQ
 1. Echap
 1. Exherbo Linux


### PR DESCRIPTION
rescinding DC201 signature due to pending internal DCG process about…matter

at hand. As a Def Con Group. We will consult direction with larger movement
before issuing a statement.

We apologize for the confusion and hope to have an update shortly