### PR TITLE
Remove a statement asking for signature via PR from Japanese translation

### DIFF
--- a/index.ja.md
+++ b/index.ja.md
@@ -14,4 +14,4 @@ RMS の言行不一致に対しても人々は寛容を示してきました。�
 
 [1]: https://rms-open-letter.github.io/appendix
 
-署名をするには digitalautonomy at riseup.net にメールを送るか、[プルリクエストを出してください](https://github.com/rms-open-letter/rms-open-letter.github.io/pulls)。
+署名をするには、digitalautonomy at riseup.net にメールを送ってください。


### PR DESCRIPTION
According to @combacsa's advice (https://github.com/rms-open-letter/rms-open-letter.github.io/pull/2262#commitcomment-48832527), I updated the Japanese translation to correspond with latest English version.
Check by other native speaker is awaited though, the change is pretty trivial (in fact it corresponds to even [Google Translate's result](https://translate.google.com/?sl=ja&tl=en&text=%E7%BD%B2%E5%90%8D%E3%82%92%E3%81%99%E3%82%8B%E3%81%AB%E3%81%AF%E3%80%81digitalautonomy%20at%20riseup.net%20%E3%81%AB%E3%83%A1%E3%83%BC%E3%83%AB%E3%82%92%E9%80%81%E3%81%A3%E3%81%A6%E3%81%8F%E3%81%A0%E3%81%95%E3%81%84%E3%80%82&op=translate)) so I guess it might be enough to have someone to confirm the reverse-translated result.